### PR TITLE
#17-fix-permissions.

### DIFF
--- a/lib/class-wp-rest-plugins-controller.php
+++ b/lib/class-wp-rest-plugins-controller.php
@@ -43,13 +43,11 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-
-		if ( ! current_user_can( 'manage_options' ) ) { // TODO: Something related to plugins. activate_plugin capability seems to not be available for multi-site superadmin (?)
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you cannot view the list of plugins' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
-
 	}
 
 	public function get_items( $request ) {
@@ -76,13 +74,11 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-
-		if ( ! current_user_can( 'manage_options' ) ) { // TODO: Something related to plugins. activate_plugin capability seems to not be available for multi-site superadmin (?)
+		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you do not have access to this resource' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
-
 	}
 
 	public function get_item( $request ) {

--- a/tests/test-rest-plugins-controller.php
+++ b/tests/test-rest-plugins-controller.php
@@ -9,6 +9,10 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 		$this->admin_id = $this->factory->user->create( array(
 			'role' => 'administrator',
 		) );
+
+		$this->subscriber = $this->factory->user->create( array(
+			'role' => 'subscriber',
+		) );
 	}
 
 	public function test_register_routes() {
@@ -27,6 +31,11 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
 
+		wp_set_current_user( $this->subscriber );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_context_param() {
@@ -52,6 +61,22 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->check_get_plugins_response( $response, 'view' );
+	}
+
+	public function test_get_item_without_permissions() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/plugins/hello-dolly' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+
+		wp_set_current_user( $this->subscriber );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_create_item() {
@@ -97,6 +122,12 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+
+		wp_set_current_user( $this->subscriber );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	protected function check_get_plugins_response( $response, $context = 'view' ) {


### PR DESCRIPTION
Fixes #17.  Currently the permissions do not match what core uses to
restric plugin access.  This does not account for multisite, which will
be added in a separate commit on a separate PR.  Tests are updated to
reflect unauthenticated and authenticated users without permissions.