### PR TITLE
Update prepare-item-response for plugin endpoint

### DIFF
--- a/lib/class-wp-rest-plugins-controller.php
+++ b/lib/class-wp-rest-plugins-controller.php
@@ -199,19 +199,53 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 
 
 	public function prepare_item_for_response( $plugin, $request ) {
-		$data = array(
-			'name'        => $plugin['Name'],
-			'plugin_uri'  => $plugin['PluginURI'],
-			'version'     => $plugin['Version'],
-			'description' => $plugin['Description'],
-			'author'      => $plugin['Author'],
-			'author_uri'  => $plugin['AuthorURI'],
-			'text_domain' => $plugin['TextDomain'],
-			'domain_path' => $plugin['DomainPath'],
-			'network'     => $plugin['Network'],
-			'title'       => $plugin['Title'],
-			'author_name' => $plugin['AuthorName'],
-		);
+		$data = array();
+
+		$schema = $this->get_item_schema();
+
+		if ( isset( $schema['properties']['name'] ) ) {
+			$data['name'] = $plugin['Name'];
+		}
+
+		if ( isset( $schema['properties']['plugin_uri'] ) ) {
+			$data['plugin_uri'] = $plugin['PluginURI'];
+		}
+
+		if ( isset( $schema['properties']['version'] ) ) {
+			$data['version'] = $plugin['Version'];
+		}
+
+		if ( isset( $schema['properties']['description'] ) ) {
+			$data['description'] = $plugin['Description'];
+		}
+
+		if ( isset( $schema['properties']['author'] ) ) {
+			$data['author'] = $plugin['Author'];
+		}
+
+		if ( isset( $schema['properties']['author_uri'] ) ) {
+			$data['author_uri'] = $plugin['AuthorURI'];
+		}
+
+		if ( isset( $schema['properties']['text_domain'] ) ) {
+			$data['text_domain'] = $plugin['TextDomain'];
+		}
+
+		if ( isset( $schema['properties']['domain_path'] ) ) {
+			$data['domain_path'] = $plugin['DomainPath'];
+		}
+
+		if ( isset( $schema['properties']['network'] ) ) {
+			$data['network'] = $plugin['Network'];
+		}
+
+		if ( isset( $schema['properties']['title'] ) ) {
+			$data['title'] = $plugin['Title'];
+		}
+
+		if ( isset( $schema['properties']['author_name'] ) ) {
+			$data['author_name'] = $plugin['AuthorName'];
+		}
 
 		return $data;
 	}

--- a/tests/test-rest-plugins-controller.php
+++ b/tests/test-rest-plugins-controller.php
@@ -40,7 +40,7 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( 2, count( $data ) );
-		$this->assertEquals( 'Akismet', $data[0]['name'] );
+
 		$this->check_get_plugins_response( $response, 'view' );
 	}
 
@@ -128,7 +128,7 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 	}
 
 	protected function check_plugin_data( $data, $context, $links ) {
-		// @TODO eventually replace with plugin collection.
+		// @TODO Eventually replace with plugin collection.
 		$plugins = get_plugins();
 		$plugin = null;
 		// Match plugin to one from collection and verify data.
@@ -146,7 +146,7 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 		$this->assertEquals( $plugin['Name'], $data['name'] );
 		$this->assertEquals( $plugin['PluginURI'], $data['plugin_uri'] );
 		$this->assertEquals( $plugin['Version'], $data['version'] );
-		// Very strange things happen with plugin description value.
+		// Very strange things happen with plugin description values.
 		$this->assertEquals( strip_tags( $plugin['Description'] ), strip_tags( $data['description'] ) );
 		$this->assertEquals( $plugin['Author'], $data['author'] );
 		$this->assertEquals( $plugin['AuthorURI'], $data['author_uri'] );
@@ -157,15 +157,5 @@ class WP_Test_REST_Plugins_Controller extends WP_Test_REST_Controller_TestCase {
 
 		// @TODO Handle active, parent, update, autoupdate.
 		// @TODO Handle context params.
-	}
-
-	protected function get_active_plugin() {
-		$plugin_file = WP_PLUGIN_DIR . '/hello.php';
-		$plugin_data = get_plugins();
-		$plugin_data = $plugin_data['hello.php'];
-		//$plugin_data = get_plugin_data( $plugin_file );
-		$plugin_data['path'] = $plugin_file;
-
-		return $plugin_data;
 	}
 }


### PR DESCRIPTION
Fixes #20. Currently the plugin endpoint's `prepare_item_for_response`
method is not tied to the schema.  It should be for future bc
compatability along with other benefits of this approach.  Currently
many other core endpoints are following this pattern.

This PR also fixes the plugin checks for data to reflect that data being
prepared for the response indeed matches data from the actual plugin
files.